### PR TITLE
disable keep full power

### DIFF
--- a/MT7668-WiFi/7668_firmware/wifi.cfg
+++ b/MT7668-WiFi/7668_firmware/wifi.cfg
@@ -60,7 +60,7 @@ EfuseBufferModeCal 1
 #RegP2pIfAtProbe 1
 Wow 1
 WowEnable 0
-SetChip0 KeepFullPwr 1
+SetChip0 KeepFullPwr 0
 TdlsBufferSTASleep 0
 ChipResetRecover 0
 CalTimingCtrl 1


### PR DESCRIPTION
Disabling allows mt7668 to regulate its power draw on demand.  Saves ~0.5W when using Ethernet, or when device is in s2idle.